### PR TITLE
fix: build process and remove 2 step build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ COPY requirements.txt .
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Set working directory
-WORKDIR /app
 
 
 # Copy the application files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.13.5-alpine@sha256:610020b9ad8ee92798f1dbe18d5e928d47358db698969d12730f9686ce3a3191 AS builder
+FROM python:3.13.5-alpine@sha256:610020b9ad8ee92798f1dbe18d5e928d47358db698969d12730f9686ce3a3191
 
 # Set working directory
 WORKDIR /app
@@ -10,15 +10,9 @@ COPY requirements.txt .
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Use a smaller base image for the final image
-FROM python:3.13.5-alpine@sha256:610020b9ad8ee92798f1dbe18d5e928d47358db698969d12730f9686ce3a3191
-
 # Set working directory
 WORKDIR /app
 
-# Copy the dependencies from the builder stage
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Copy the application files
 COPY app /app


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified Docker build by removing multi-stage build process

- Eliminated unnecessary builder stage and dependency copying

- Streamlined Dockerfile structure for single-stage build


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Multi-stage Dockerfile"] --> B["Single-stage Dockerfile"]
  C["Builder stage"] --> D["Direct dependency installation"]
  E["COPY --from=builder"] --> F["Direct file copying"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Convert multi-stage to single-stage Docker build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Removed <code>AS builder</code> from base image declaration<br> <li> Eliminated second <code>FROM</code> statement for multi-stage build<br> <li> Removed <code>COPY --from=builder</code> commands for dependencies<br> <li> Added trailing newline at end of file


</details>


  </td>
  <td><a href="https://github.com/GlueOps/storypoints/pull/34/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>